### PR TITLE
Fix AVAX reward transfer to smart contract

### DIFF
--- a/Comptroller.sol
+++ b/Comptroller.sol
@@ -1279,7 +1279,8 @@ contract Comptroller is ComptrollerVXStorage, ComptrollerInterface, ComptrollerE
         } else if (rewardType == 1) {
             uint avaxRemaining = address(this).balance;
             if (amount > 0 && amount <= avaxRemaining) {
-                user.transfer(amount);
+                (bool success, ) = user.call{value: amount}("");
+                require(success, "Address: unable to send value, user may have reverted");
                 return 0;
             }
         }


### PR DESCRIPTION
Currently, AVAX rewards are being transferred using `.transfer()` function. And because of using `.transfer()` function it only forwards 2300 gas and transferring AVAX rewards to a smart contract might throw an "out of gas" error. 

And since Instadapp's DSA is a smart contract wallet and not able to claim AVAX rewards for DSA.